### PR TITLE
fix: Deployment error and update timeouts

### DIFF
--- a/parma_mining/discord/client.py
+++ b/parma_mining/discord/client.py
@@ -29,6 +29,7 @@ class DiscordClient:
                 "Authorization": self.authorization_key,
             },
             params=params,
+            timeout=30,
         )
 
     def get_channel_messages(

--- a/terraform/module/main.tf
+++ b/terraform/module/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.6"
+      version = "5.12.0"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/terraform/module/service.tf
+++ b/terraform/module/service.tf
@@ -32,6 +32,15 @@ resource "google_cloud_run_service" "parma_mining_discord_cloud_run" {
     spec {
       containers {
         image = data.local_file.image_name.content
+
+        resources {
+          limits = {
+            # 0.5 vCPU, 256 MB RAM for ${var.env} == staging, else 1 vCPU, 512 MB RAM
+            cpu    = var.env == "staging" ? "1" : "1"
+            memory = var.env == "staging" ? "256Mi" : "512Mi"
+          }
+        }
+
         ports {
           container_port = 8080
         }
@@ -49,6 +58,13 @@ resource "google_cloud_run_service" "parma_mining_discord_cloud_run" {
         }
       }
     }
+
+    metadata {
+      annotations = {
+        "autoscaling.knative.dev/maxScale" = "10"
+      }
+    }
+
   }
 
   traffic {

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.6"
+      version = "5.12.0"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.6"
+      version = "5.12.0"
     }
     docker = {
       source  = "kreuzwerker/docker"


### PR DESCRIPTION
# Motivation

GCP made some API adjustments invalidating the defaults in our used terraform providers.

httpx’s default timeout of 5 seconds is updated.